### PR TITLE
feat: 예매처 정보 업데이트 로직 개선 및 중복 스크래핑 방지

### DIFF
--- a/src/main/java/com/everyplaceinkorea/epik_boot3_api/external/kopis/service/TicketOfficeSyncService.java
+++ b/src/main/java/com/everyplaceinkorea/epik_boot3_api/external/kopis/service/TicketOfficeSyncService.java
@@ -28,8 +28,8 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * KOPIS 스크래핑 결과와 수기 입력 데이터를 병합하여
- * Musical/Concert 엔티티의 예매처 정보를 동기화하는 서비스
+ * KOPIS 웹사이트 스크래핑 결과와 데이터베이스에 수기로 입력된 데이터를 병합하여,
+ * Musical 및 Concert 엔티티의 예매처 정보를 동기화(업데이트)하는 서비스
  */
 @Service
 @RequiredArgsConstructor
@@ -43,9 +43,11 @@ public class TicketOfficeSyncService {
   private final ConcertTicketOfficeRepository concertTicketOfficeRepository;
 
   /**
-   * 뮤지컬 예매처 정보를 스크래핑하여 기존 수기 데이터 및 JSON과 병합 후 저장
+   * 특정 뮤지컬의 예매처 정보를 스크래핑하고, 기존 데이터 병합하여 업데이트
+   * KOPIS 웹사이트에서 스크래핑한 데이터, DB에 수기 입력된 데이터, 엔티티의 JSON 필드
+   * 데이터를 병합하여 최종 결과를 다시 엔티티의 JSON 필드에 저장
    *
-   * @param musicalId 대상 뮤지컬의 ID
+   * @param musicalId 예매처 정보를 업데이트할 뮤지컬의 데이터베이스 ID
    */
   @Transactional
   public void updateMusicalTicketOffices(Long musicalId) {
@@ -90,9 +92,9 @@ public class TicketOfficeSyncService {
   }
 
   /**
-   * 콘서트 예매처 정보를 스크래핑하여 기존 수기 데이터 및 JSON과 병합 후 저장
+   * 특정 콘서트의 예매처 정보를 스크래핑하고, 기존 데이터와 병합하여 업데이트
    *
-   * @param concertId 대상 콘서트의 ID
+   * @param concertId 예매처 정보를 업데이트할 콘서트 데이터베이스 ID
    */
   @Transactional
   public void updateConcertTicketOffices(Long concertId) {
@@ -139,12 +141,13 @@ public class TicketOfficeSyncService {
   }
 
   /**
-   * 뮤지컬의 기존 JSON/수기 입력 예매처와 스크래핑 결과 병합
-   * 스크래핑 데이터가 동일 키의 기존 값을 덮어씀
+   * 뮤지컬의 예매처 데이터를 병합
+   * 병합 우선순위: 1. 기존 JSON 필드 -> 2. 수기 입력 테이블 -> 3. 스크래핑 결과
+   * 동일한 예매처 이름(정규화된 키)이 존재할 경우, 나중에 추가된 데이터가 이전 데이터를 덮어씀
    *
-   * @param musical 대상 뮤지컬 엔티티
-   * @param scrapedOffices 스크래핑된 예매처 리스트
-   * @return 병합된 예매처 맵 (key: 정규화명, value: url)
+   * @param musical 병합 대상 뮤지컬 엔티티
+   * @param scrapedOffices 스크래핑으로 수집된 예매처 정보 리스트
+   * @return 병합된 예매처 맵 (key: 정규화된 예매처 이름, value: 예매처 URL)
    */
   private Map<String, String> mergeMusicalTicketOffices(Musical musical, List<TicketOfficeScrapeResult> scrapedOffices) {
     Map<String, String> result = new HashMap<>();
@@ -173,12 +176,11 @@ public class TicketOfficeSyncService {
   }
 
   /**
-   * 콘서트의 기존 JSON/수기 입력 예매처와 스크래핑 결과 병합
-   * 스크래핑 데이터가 동일 키의 기존 값을 덮어씀
+   * 콘서트의 예매처 데이터를 병합
    *
-   * @param concert 대상 콘서트 엔티티
-   * @param scrapedOffices 스크래핑된 예매처 리스트
-   * @return 병합된 예매처 맵 (key: 정규화명, value: url)
+   * @param concert 병합 대상 콘서트 엔티티
+   * @param scrapedOffices 스크래핑으로 수집된 예매처 정보 리스트
+   * @return 병합된 예매처 맵 (key: 정규화된 예매처 이름, value: 예매처 URL)
    */
   private Map<String, String> mergeConcertTicketOffices(Concert concert, List<TicketOfficeScrapeResult> scrapedOffices) {
     Map<String, String> result = new HashMap<>();
@@ -207,10 +209,11 @@ public class TicketOfficeSyncService {
   }
 
   /**
-   * 예매처 표시명을 비교/병합용 키로 사용할 수 있도록 정규화
+   * 예매처 이름을 정규화하여 일관된 키로 사용하도록 변환
+   * 주요 예매처는 사전 정의된 키로 매핑하며, 그 외에는 공백과 특수문자를 제거
    *
    * @param name 원본 예매처 이름
-   * @return 정규화된 키(주요 브랜드는 사전 매핑, 그 외는 영문, 숫자만 남김)
+   * @return 정규화된 예매처 이름(키)
    */
   private String normalizeOfficeName(String name) {
     if (name == null) return "other";
@@ -245,7 +248,7 @@ public class TicketOfficeSyncService {
   }
 
   /**
-   * 콘서트 예메처 데이터의 출처 계산
+   * 콘서트 예매처 데이터의 출처 계산
    *
    * @param concert 대상 콘서트 엔티티
    * @param scrapedOffices 스크래핑된 예매처 리스트
@@ -272,13 +275,17 @@ public class TicketOfficeSyncService {
 
     int successCount = 0;
     int failCount = 0;
+    int skipCount = 0;
 
     for (Musical musical : musicals) {
       try {
+        if(hasMusicalTicketOfficeData(musical)) {
+          skipCount++;
+          log.info("예매처 데이터가 이미 존재하여 건너뜀: ID={}, 제목={}", musical.getId(), musical.getTitle());
+          continue;
+        }
         updateMusicalTicketOffices(musical.getId());
         successCount++;
-
-        // 요청 간 딜레이 (서버 부하 방지)
         Thread.sleep(3000); // 3초 대기
 
       } catch (Exception e) {
@@ -288,23 +295,27 @@ public class TicketOfficeSyncService {
       }
     }
 
-    log.info("전체 뮤지컬 예매처 정보 업데이트 완료: 성공={}, 실패={}", successCount, failCount);
+    log.info("전체 뮤지컬 예매처 정보 업데이트 완료: 성공={}, 실패={}, 건너뜀={}", successCount, failCount, skipCount);
   }
 
   /**
-   * 최근 5개의 뮤지컬에 대해 예매처 정보를 테스트 목적으로 업데이트
+   * 최근 15개의 뮤지컬에 대해 예매처 정보를 테스트 목적으로 업데이트
    */
   public void updateRecentMusicalTicketOffices() {
     LocalDateTime startTime = LocalDateTime.now();
-    log.info("=== 최근 5개 뮤지컬 데이터 예매처 정보 업데이트 시작 (테스트) ===");
+    log.info("=== 예매처 데이터가 없는 최근 15개 예매처 정보 업데이트 시작 ===");
     log.info("테스트 시작시간: {}", startTime);
 
-    // 최근 5개만 가져오기 (ID 기준 내림차순)
     Pageable pageable = PageRequest.of(0, 15, Sort.by("id").descending());
-    Page<Musical> musicalPage = musicalRepository.findAll(pageable);
+    Page<Musical> musicalPage = musicalRepository.findMusicalsWithoutTicketOffices(pageable);
     List<Musical> musicals = musicalPage.getContent();
 
     log.info("업데이트할 뮤지컬 컨텐츠 개수: {}", musicals.size());
+
+    if(musicals.isEmpty()) {
+      log.info("예매처 데이터가 없는 뮤지컬이 없습니다. 업데이트 종료.");
+      return;
+    }
 
     int successCount = 0;
     int failCount = 0;
@@ -328,7 +339,7 @@ public class TicketOfficeSyncService {
     LocalDateTime endTime = LocalDateTime.now();
     Duration duration = Duration.between(startTime, endTime);
 
-    log.info("=== 최근 5개 뮤지컬 예매처 정보 업데이트 완료 ===");
+    log.info("=== 예매처 데이터가 없는 최근 15개 뮤지컬 예매처 정보 업데이트 완료 ===");
     log.info("1. 완료시간: {}", endTime);
     log.info("2. 총 소요시간: {}초", duration.toSeconds());
     log.info("3. 성공: {}개, 실패: {}개", successCount, failCount);
@@ -345,13 +356,17 @@ public class TicketOfficeSyncService {
 
     int successCount = 0;
     int failCount = 0;
+    int skipCount = 0;
 
     for(Concert concert : concerts) {
       try {
+        if(hasConcertTicketOfficeData(concert)) {
+          skipCount++;
+          log.info("예매처 데이터가 이미 존재하여 건너뜀: ID={}, 제목={}", concert.getId(), concert.getTitle());
+          continue;
+        }
         updateConcertTicketOffices(concert.getId());
         successCount++;
-
-        // 요청 간 딜레이 (서버 부하 방지)
         Thread.sleep(3000);
 
       } catch(Exception e) {
@@ -361,23 +376,27 @@ public class TicketOfficeSyncService {
       }
     }
 
-    log.info("전체 콘서트 예매처 정보 업데이트 완료: 성공={}, 실패={}", successCount, failCount);
+    log.info("전체 콘서트 예매처 정보 업데이트 완료: 성공={}, 실패={}, 건너뜀={}", successCount, failCount, skipCount);
   }
 
   /**
-   * 최신 5개의 콘서트에 대해 예매처 정보를 테스트 목적으로 업데이트
+   * 최신 15개의 콘서트에 대해 예매처 정보를 테스트 목적으로 업데이트
    */
   public void updateRecentConcertTicketOffices() {
     LocalDateTime startTime = LocalDateTime.now();
-    log.info("=== 최근 5개 콘서트 데이터 예매처 정보 업데이트 시작 (테스트) ===");
+    log.info("=== 예매처 데이터가 없는 최근 15개 예매처 정보 업데이트 시작 ===");
     log.info("콘서트 예매처 테스트 시작시간: {}", startTime);
 
-    // 최근 5개만 가져오기 (ID 기준 내림차순)
     Pageable pageable = PageRequest.of(0, 15, Sort.by("id").descending());
-    Page<Concert> concertPage = concertRepository.findAll(pageable);
+    Page<Concert> concertPage = concertRepository.findConcertsWithoutTicketOffices(pageable);
     List<Concert> concerts = concertPage.getContent();
 
     log.info("업데이트할 콘서트 컨텐츠 개수: {}", concerts.size());
+
+    if(concerts.isEmpty()) {
+      log.info("예매처 데이터가 없는 콘서트가 없습니다. 업데이트 종료.");
+      return;
+    }
 
     int successCount = 0;
     int failCount = 0;
@@ -394,16 +413,35 @@ public class TicketOfficeSyncService {
         log.info("콘서트 처리 완료 [{}/{}]: ID={}", i + 1, concerts.size(), concert.getId());
       } catch (Exception e) {
         failCount++;
-        log.error("콘서트 예매처 업데이트 실패 [{}/{}]: Musical ID={}, 에러={}",
+        log.error("콘서트 예매처 업데이트 실패 [{}/{}]: Concert ID={}, 에러={}",
                 i + 1, concerts.size(), concert.getId(), e.getMessage());
       }
     }
     LocalDateTime endTime = LocalDateTime.now();
     Duration duration = Duration.between(startTime, endTime);
 
-    log.info("=== 최근 5개 콘서트 예매처 정보 업데이트 완료 ===");
-    log.info("완료시간: {}", endTime);
-    log.info("총 소요시간: {}초", duration.toSeconds());
-    log.info("성공: {}개, 실패: {}개", successCount, failCount);
+    log.info("=== 예매처 데이터가 없는 최근 15개 콘서트 예매처 정보 업데이트 완료 ===");
+    log.info("1. 완료시간: {}", endTime);
+    log.info("2. 총 소요시간: {}초", duration.toSeconds());
+    log.info("3. 성공: {}개, 실패: {}개", successCount, failCount);
+  }
+
+  private boolean hasMusicalTicketOfficeData(Musical musical) {
+    boolean hasJsonData = musical.getKopisTicketOffices() != null
+            && !musical.getKopisTicketOffices().trim().isEmpty()
+            && !musical.getKopisTicketOffices().equals("{}");
+
+    boolean hasManualData = !musicalTicketOfficeRepository.findByMusical(musical).isEmpty();
+    return hasJsonData || hasManualData;
+  }
+
+  private boolean hasConcertTicketOfficeData(Concert concert) {
+    boolean hasJsonData = concert.getKopisTicketOffices() != null
+            && !concert.getKopisTicketOffices().trim().isEmpty()
+            && !concert.getKopisTicketOffices().equals("{}");
+
+    boolean hasManualData = !concertTicketOfficeRepository.findByConcert(concert).isEmpty();
+
+    return hasJsonData || hasManualData;
   }
 }

--- a/src/main/java/com/everyplaceinkorea/epik_boot3_api/repository/concert/ConcertRepository.java
+++ b/src/main/java/com/everyplaceinkorea/epik_boot3_api/repository/concert/ConcertRepository.java
@@ -64,4 +64,7 @@ public interface ConcertRepository extends JpaRepository<Concert, Long> {
 
   List<Concert> findByFacilityIsNotNullAndHallIsNull();
 
+  @Query("SELECT c FROM Concert c WHERE c.kopisId IS NOT NULL " +
+          "AND (c.kopisTicketOffices IS NULL OR c.kopisTicketOffices = '{}' OR c.kopisTicketOffices = '')")
+  Page<Concert> findConcertsWithoutTicketOffices(Pageable pageable);
 }

--- a/src/main/java/com/everyplaceinkorea/epik_boot3_api/repository/musical/MusicalRepository.java
+++ b/src/main/java/com/everyplaceinkorea/epik_boot3_api/repository/musical/MusicalRepository.java
@@ -95,4 +95,7 @@ public interface MusicalRepository extends JpaRepository<Musical, Long> {
 
     List<Musical> findByFacilityIsNotNullAndHallIsNull();
 
+    @Query("SELECT m FROM Musical m WHERE m.kopisId IS NOT NULL " +
+            "AND (m.kopisTicketOffices IS NULL OR m.kopisTicketOffices = '{}' OR m.kopisTicketOffices = '')")
+    Page<Musical> findMusicalsWithoutTicketOffices(Pageable pageable);
 }


### PR DESCRIPTION
KOPIS 웹 스크래핑 기반 예매처 정보 업데이트 시스템을 개선하여 중복 작업을 방지

주요 변경 사항:
- 이미 예매처 데이터가 존재하는 항목 자동 건너뛰기 기능 추가
- 예매처 데이터가 없는 항목만 조회하는 Repository 쿼리 메서드 추가
- 전체 업데이트/최근 업데이트 모두 중복 스크래핑 방지 로직 적용
- 불필요한 웹 스크래핑 작업 제거로 업데이트 시간 단축