### PR TITLE
PR - 뮤지컬 북마크 기능 구현

### DIFF
--- a/src/main/java/com/everyplaceinkorea/epik_boot3_api/member/concert/service/DefaultConcertService.java
+++ b/src/main/java/com/everyplaceinkorea/epik_boot3_api/member/concert/service/DefaultConcertService.java
@@ -8,6 +8,7 @@ import com.everyplaceinkorea.epik_boot3_api.member.concert.dto.ConcertResponseDt
 import com.everyplaceinkorea.epik_boot3_api.repository.Member.MemberRepository;
 import com.everyplaceinkorea.epik_boot3_api.repository.concert.ConcertBookmarkRepository;
 import com.everyplaceinkorea.epik_boot3_api.repository.concert.ConcertRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -30,28 +31,18 @@ public class DefaultConcertService implements ConcertService {
     @Override
     public List<ConcertResponseDto> getBookmark(Long id) {
         List<ConcertBookmark> bookmarks = concertBookmarkRepository.findConcertBookmarksByMemberId(id);
-        List<Concert> concerts = bookmarks.stream()
+
+        return bookmarks.stream()
                 .map(ConcertBookmark::getConcert)
+                .map(concert -> ConcertResponseDto.builder()
+                        .id(concert.getId())
+                        .title(concert.getTitle())
+                        .startDate(concert.getStartDate())
+                        .endDate(concert.getEndDate())
+                        .venue(concert.getVenue())
+                        .saveImageName(concert.getFileSavedName())
+                        .build())
                 .collect(Collectors.toList());
-
-        List<ConcertResponseDto> responseDtos = new ArrayList<>();
-
-        concerts.forEach(concert -> {
-            Long concertId = concert.getId();
-            Concert findConcert = concertRepository.findById(concertId).orElseThrow();
-            ConcertResponseDto responseDto = ConcertResponseDto.builder()
-                    .id(findConcert.getId())
-                    .title(findConcert.getTitle())
-                    .startDate(findConcert.getStartDate())
-                    .endDate(findConcert.getEndDate())
-                    .venue(findConcert.getVenue())
-                    .saveImageName(findConcert.getFileSavedName())
-                    .build();
-
-            responseDtos.add(responseDto);
-        });
-
-        return responseDtos;
     }
 
     // 북마크 상태 조회
@@ -83,9 +74,9 @@ public class DefaultConcertService implements ConcertService {
             return bookmark.getIsActive();
         } else {
             Concert concert = concertRepository.findById(concertId)
-                    .orElseThrow(() -> new RuntimeException("Concert not found"));
+                    .orElseThrow(() -> new EntityNotFoundException("Concert not found with id: " + concertId));
             Member member = memberRepository.findById(memberId)
-                    .orElseThrow(() -> new RuntimeException("Member not found"));
+                    .orElseThrow(() -> new EntityNotFoundException("Member not found with id: " + memberId));
 
             ConcertBookmark newBookmark = new ConcertBookmark();
             newBookmark.setId(id);

--- a/src/main/java/com/everyplaceinkorea/epik_boot3_api/member/musical/controller/MusicalController.java
+++ b/src/main/java/com/everyplaceinkorea/epik_boot3_api/member/musical/controller/MusicalController.java
@@ -76,7 +76,7 @@ public class MusicalController {
             log.error("북마크 토글 중 오류 발생: ", e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of(
                     "success", false,
-                    "message", "북마크 처리 중 오류가 발생헀습니다."
+                    "message", "북마크 처리 중 오류가 발생했습니다."
             ));
         }
     }

--- a/src/main/java/com/everyplaceinkorea/epik_boot3_api/member/musical/service/DefaultMusicalService.java
+++ b/src/main/java/com/everyplaceinkorea/epik_boot3_api/member/musical/service/DefaultMusicalService.java
@@ -8,6 +8,7 @@ import com.everyplaceinkorea.epik_boot3_api.member.musical.dto.MusicalResponseDt
 import com.everyplaceinkorea.epik_boot3_api.repository.Member.MemberRepository;
 import com.everyplaceinkorea.epik_boot3_api.repository.musical.MusicalBookmarkRepository;
 import com.everyplaceinkorea.epik_boot3_api.repository.musical.MusicalRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -30,29 +31,18 @@ public class DefaultMusicalService implements MusicalService {
     @Override
     public List<MusicalResponseDto> getBookmark(Long id) {
         List<MusicalBookmark> bookmarks = musicalBookmarkRepository.findMusicalBookmarksByMemberId(id);
-        List<Musical> musicals = bookmarks.stream()
+
+        return bookmarks.stream()
                 .map(MusicalBookmark::getMusical)
+                .map(musical -> MusicalResponseDto.builder()
+                        .id(musical.getId())
+                        .title(musical.getTitle())
+                        .startDate(musical.getStartDate())
+                        .endDate(musical.getEndDate())
+                        .venue(musical.getVenue())
+                        .saveImageName(musical.getFileSavedName())
+                        .build())
                 .collect(Collectors.toList());
-
-        List<MusicalResponseDto> responseDtos = new ArrayList<>();
-
-                musicals.forEach(Musical -> {
-            Long musicalId = Musical.getId();
-            Musical findMusical = musicalRepository.findById(musicalId).orElseThrow();
-            MusicalResponseDto responseDto = MusicalResponseDto.builder()
-                    .id(findMusical.getId())
-                    .title(findMusical.getTitle())
-                    .startDate(findMusical.getStartDate())
-                    .endDate(findMusical.getEndDate())
-                    .venue(findMusical.getVenue())
-                    .saveImageName(findMusical.getFileSavedName())
-                    .build();
-
-            responseDtos.add(responseDto);
-
-        });
-
-        return responseDtos;
     }
 
     @Override
@@ -82,9 +72,9 @@ public class DefaultMusicalService implements MusicalService {
             return bookmark.getIsActive();
         } else {
             Musical musical = musicalRepository.findById(musicalId)
-                    .orElseThrow(() -> new RuntimeException("Musical not found"));
+                    .orElseThrow(() -> new EntityNotFoundException("Musical not found with id: " + musicalId));
             Member member = memberRepository.findById(memberId)
-                    .orElseThrow(() -> new RuntimeException("Member not found"));
+                    .orElseThrow(() -> new RuntimeException("Member not found with id: " + memberId));
 
             MusicalBookmark newBookmark = new MusicalBookmark();
             newBookmark.setId(id);
@@ -96,6 +86,4 @@ public class DefaultMusicalService implements MusicalService {
             return true;
         }
     }
-
-
 }

--- a/src/main/java/com/everyplaceinkorea/epik_boot3_api/member/musical/service/MusicalService.java
+++ b/src/main/java/com/everyplaceinkorea/epik_boot3_api/member/musical/service/MusicalService.java
@@ -5,7 +5,6 @@ import com.everyplaceinkorea.epik_boot3_api.member.musical.dto.MusicalResponseDt
 import java.util.List;
 
 public interface MusicalService {
-    // 북마크
     List<MusicalResponseDto> getBookmark(Long id);
     boolean isBookmarked(Long musicalId, Long memberId);
     boolean toggleBookmark(Long musicalId, Long memberId);


### PR DESCRIPTION
### 구현 내용:
- **MusicalController.java**
  * GET `/member/musical/{id}/bookmark/status` - 북마크 상태 조회
  * POST `/member/musical/{id}/bookmark/toggle` - 북마크 토글 (수정)
  * GET `/member/musical/{id}/bookmark` - 회원 북마크 목록

- **DefaultMusicalService.java**
  * `isBookmarked()` - 북마크 상태 조회
  * `toggleBookmark()` - 북마크 토글 (추가/삭제)
  * `getBookmark()` - 회원의 뮤지컬 북마크 목록

- **MusicalBookmark 엔티티**
  * 복합키 구조 (musical_id, member_id)
  * isActive 필드로 soft delete 지원
  * `@Transactional`로 데이터 일관성 보장

### 동작 흐름:
1. 기존 북마크 존재 시: isActive 토글
2. 북마크 없을 시: 새 북마크 생성 (isActive=true)
3. 변경된 상태 반환 (true/false)

비고:
- Concert 북마크와 동일한 구조 및 로직 적용
- Exhibition 북마크도 동일하게 구현 가능