### PR TITLE
PR: 예매처 스크래핑 재시도 로직 개선 및 실패 관리 구현

### DIFF
--- a/src/main/java/com/everyplaceinkorea/epik_boot3_api/admin/contents/concert/dto/ConcertResponseDto.java
+++ b/src/main/java/com/everyplaceinkorea/epik_boot3_api/admin/contents/concert/dto/ConcertResponseDto.java
@@ -49,4 +49,8 @@ public class ConcertResponseDto {
     }
     return null; // 이미지가 없는 경우
   }
+
+  public String getRunningTime() {
+    return runningTime != null ? runningTime : "예매처 확인";
+  }
 }

--- a/src/main/java/com/everyplaceinkorea/epik_boot3_api/admin/contents/musical/dto/MusicalResponseDto.java
+++ b/src/main/java/com/everyplaceinkorea/epik_boot3_api/admin/contents/musical/dto/MusicalResponseDto.java
@@ -54,4 +54,8 @@ public class MusicalResponseDto {
         }
         return null;
     }
+
+    public String getRunningTime() {
+        return runningTime != null ? runningTime : "예매처 확인";
+    }
 }

--- a/src/main/java/com/everyplaceinkorea/epik_boot3_api/entity/concert/Concert.java
+++ b/src/main/java/com/everyplaceinkorea/epik_boot3_api/entity/concert/Concert.java
@@ -216,15 +216,6 @@ public class Concert {
   public void updateFromKopisDetailData(KopisPerformanceDto dto) {
     log.debug("상세 정보 업데이트 시작: {}", this.title);
 
-    // 공연시간 정보 업데이트
-    if (isValidString(dto.getPrftime())) {
-      // 러닝타임 정보 추출 및 업데이트
-      String extractedTime = KopisDataUtils.extractRunningTime(dto.getPrftime());
-      if (extractedTime != null) {
-        this.runningTime = extractedTime;
-      }
-    }
-
     // 티켓가격 정보 업데이트
     if (isValidString(dto.getPcseguidance())) {
       this.ticketPrice = dto.getPcseguidance();

--- a/src/main/java/com/everyplaceinkorea/epik_boot3_api/entity/concert/Concert.java
+++ b/src/main/java/com/everyplaceinkorea/epik_boot3_api/entity/concert/Concert.java
@@ -127,6 +127,9 @@ public class Concert {
   @Column(name = "kopis_ticket_offices_updated_at")
   private LocalDateTime kopisTicketOfficesUpdatedAt;
 
+  @Column(name = "kopis_ticket_scrape_fail_count")
+  private Integer kopisTicketScrapeFailCount = 0;
+
   @Enumerated(EnumType.STRING)
   @Column(name = "kopis_ticket_offices_source")
   private TicketOfficeSource kopisTicketOfficesSource = TicketOfficeSource.MANUAL;

--- a/src/main/java/com/everyplaceinkorea/epik_boot3_api/entity/musical/Musical.java
+++ b/src/main/java/com/everyplaceinkorea/epik_boot3_api/entity/musical/Musical.java
@@ -238,15 +238,6 @@ public class Musical {
     public void updateFromKopisDetailData(KopisPerformanceDto dto) {
         log.debug("상세 정보 업데이트 시작: {}", this.title);
 
-        // 공연시간 정보 업데이트
-        if (isValidString(dto.getPrftime())) {
-            // 러닝타임 정보 추출 및 업데이트
-            String extractedTime = KopisDataUtils.extractRunningTime(dto.getPrftime());
-            if (extractedTime != null) {
-                this.runningTime = extractedTime;
-            }
-        }
-
         // 티켓가격 정보 업데이트
         if (isValidString(dto.getPcseguidance())) {
             this.kopisPcseguidance = dto.getPcseguidance();

--- a/src/main/java/com/everyplaceinkorea/epik_boot3_api/entity/musical/Musical.java
+++ b/src/main/java/com/everyplaceinkorea/epik_boot3_api/entity/musical/Musical.java
@@ -121,6 +121,9 @@ public class Musical {
     @Column(name = "kopis_ticket_offices_updated_at")
     private LocalDateTime kopisTicketOfficesUpdatedAt;
 
+    @Column(name = "kopis_ticket_scrape_fail_count")
+    private Integer kopisTicketScrapeFailCount = 0;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "kopis_ticket_offices_source")
     private TicketOfficeSource kopisTicketOfficesSource = TicketOfficeSource.MANUAL;

--- a/src/main/java/com/everyplaceinkorea/epik_boot3_api/external/kopis/service/TicketOfficeSyncService.java
+++ b/src/main/java/com/everyplaceinkorea/epik_boot3_api/external/kopis/service/TicketOfficeSyncService.java
@@ -4,6 +4,7 @@ import com.everyplaceinkorea.epik_boot3_api.entity.concert.Concert;
 import com.everyplaceinkorea.epik_boot3_api.entity.concert.ConcertTicketOffice;
 import com.everyplaceinkorea.epik_boot3_api.entity.musical.Musical;
 import com.everyplaceinkorea.epik_boot3_api.entity.musical.MusicalTicketOffice;
+import com.everyplaceinkorea.epik_boot3_api.external.kopis.config.ScrapingProperties;
 import com.everyplaceinkorea.epik_boot3_api.external.kopis.dto.MigrationResult;
 import com.everyplaceinkorea.epik_boot3_api.external.kopis.dto.TicketOfficeScrapeResult;
 import com.everyplaceinkorea.epik_boot3_api.external.kopis.enums.TicketOfficeSource;
@@ -35,6 +36,7 @@ import java.util.*;
 @Slf4j
 public class TicketOfficeSyncService {
 
+  private final ScrapingProperties scrapingProperties;
   private final KopisWebScraperService scraperService;
   private final MusicalRepository musicalRepository;
   private final ConcertRepository concertRepository;
@@ -67,12 +69,8 @@ public class TicketOfficeSyncService {
 
     try {
       // 1. 스크래핑으로 예매처 정보 수집
-      List<TicketOfficeScrapeResult> scrapedOffices = scraperService.scrapeTicketOffices(kopisId);
-
-      if(scrapedOffices.isEmpty()) {
-        log.info("스크래핑된 예매처 정보가 없음: KOPIS ID={}", kopisId);
-        return;
-      }
+      List<TicketOfficeScrapeResult> scrapedOffices = scrapeWithRetry(kopisId, musical);
+      if (scrapedOffices.isEmpty()) return;
 
       // 2. 기존 수기입력 데이터와 병합
       Map<String, String> finalOffices = mergeMusicalTicketOffices(musical, scrapedOffices);
@@ -114,12 +112,8 @@ public class TicketOfficeSyncService {
 
     try {
       // 1. 스크래핑으로 예매처 정보 수집
-      List<TicketOfficeScrapeResult> scrapedOffices = scraperService.scrapeTicketOffices(kopisId);
-
-      if (scrapedOffices.isEmpty()) {
-        log.info("스크래핑된 예매처 정보가 없음: KOPIS ID={}", kopisId);
-        return;
-      }
+      List<TicketOfficeScrapeResult> scrapedOffices = scrapeWithRetry(kopisId, concert);
+      if (scrapedOffices.isEmpty()) return;
 
       // 2. 기존 수기입력 데이터와 병합
       Map<String, String> finalOffices = mergeConcertTicketOffices(concert, scrapedOffices);
@@ -556,5 +550,73 @@ public class TicketOfficeSyncService {
             .noDataCount(noDataCount)
             .totalTarget(concerts.size())
             .build();
+  }
+
+  private List<TicketOfficeScrapeResult> scrapeWithRetry(String kopisId, Concert concert) {
+    int maxRetry = scrapingProperties.getMaxRetryCount();
+
+    for(int attempt = 1; attempt <= maxRetry; attempt++) {
+      List<TicketOfficeScrapeResult> result = scraperService.scrapeTicketOffices(kopisId);
+
+      if(!result.isEmpty()) {
+        concert.setKopisTicketScrapeFailCount(0);
+        return result;
+      }
+
+      log.warn("예매처 스크래핑 결과 없음 (시도 {}/{}): KOPIS ID={}", attempt, maxRetry, kopisId);
+
+      if(attempt < maxRetry) {
+        try {
+          Thread.sleep(3000);
+        } catch (InterruptedException ignored) {}
+      }
+    }
+
+    // 모든 재시도 실패
+    int failCount = concert.getKopisTicketScrapeFailCount() == null ? 1 : concert.getKopisTicketScrapeFailCount() + 1;
+    concert.setKopisTicketScrapeFailCount(failCount);
+
+    if(failCount >= maxRetry) {
+      // 임계값 도달 -> 진짜 없는 것으로 판단, 이후 배치에서 제외
+      log.info("예매처 없음 (fail_count={}), KOPIS_ID={}", failCount, kopisId);
+      concert.setKopisTicketOfficesUpdatedAt(LocalDateTime.now());
+    }
+
+    concertRepository.save(concert);
+    return Collections.emptyList();
+  }
+
+  private List<TicketOfficeScrapeResult> scrapeWithRetry(String kopisId, Musical musical) {
+    int maxRetry = scrapingProperties.getMaxRetryCount();
+
+    for(int attempt = 1; attempt <= maxRetry; attempt++) {
+      List<TicketOfficeScrapeResult> result = scraperService.scrapeTicketOffices(kopisId);
+
+      if(!result.isEmpty()) {
+        musical.setKopisTicketScrapeFailCount(0);
+        return result;
+      }
+
+      log.warn("예매처 스크래핑 결과 없음 (시도 {}/{}): KOPIS ID={}", attempt, maxRetry, kopisId);
+
+      if(attempt < maxRetry) {
+        try {
+          Thread.sleep(3000);
+        } catch (InterruptedException ignored) {}
+      }
+    }
+
+    // 모든 재시도 실패
+    int failCount = musical.getKopisTicketScrapeFailCount() == null ? 1 : musical.getKopisTicketScrapeFailCount() + 1;
+    musical.setKopisTicketScrapeFailCount(failCount);
+
+    if(failCount >= maxRetry) {
+      // 임계값 도달 -> 진짜 없는 것으로 판단, 이후 배치에서 제외
+      log.info("예매처 없음 (fail_count={}), KOPIS_ID={}", failCount, kopisId);
+      musical.setKopisTicketOfficesUpdatedAt(LocalDateTime.now());
+    }
+
+    musicalRepository.save(musical);
+    return Collections.emptyList();
   }
 }

--- a/src/main/java/com/everyplaceinkorea/epik_boot3_api/external/kopis/utils/KopisDataUtils.java
+++ b/src/main/java/com/everyplaceinkorea/epik_boot3_api/external/kopis/utils/KopisDataUtils.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * KOPIS 데이터 처리 공통 유틸리티 클래스
@@ -88,73 +90,9 @@ public class KopisDataUtils {
      */
     public static String determineRunningTime(KopisPerformanceDto dto) {
         if (isValidString(dto.getPrfruntime())) {
-            return convertToMinutes(dto.getPrfruntime());
+            return dto.getPrfruntime();
         }
         return null;
-    }
-
-    /**
-     * 시간 표현을 분 단위로 통일 (정교한 정규식 사용)
-     * 예: "2시간" -> "120분", "1시간 30분" -> "90분", "총 90분" -> "90분"
-     *
-     * @param timeStr 시간 문자열
-     * @return 분 단위 문자열 (변환 실패 시 원본 반환)
-     */
-    public static String convertToMinutes(String timeStr) {
-        if (timeStr == null || timeStr.trim().isEmpty()) {
-            return null;
-        }
-
-        try {
-            // "총 120분", "120분" 패턴
-            java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("(총\\s*)?(\\d+)분");
-            java.util.regex.Matcher matcher = pattern.matcher(timeStr);
-
-            if (matcher.find()) {
-                return matcher.group(2) + "분";
-            }
-
-            // "2시간 30분", "2시간" 패턴
-            pattern = java.util.regex.Pattern.compile("(\\d+)시간\\s*(\\d+)?분?");
-            matcher = pattern.matcher(timeStr);
-
-            if (matcher.find()) {
-                int hours = Integer.parseInt(matcher.group(1));
-                int minutes = matcher.group(2) != null ? Integer.parseInt(matcher.group(2)) : 0;
-                int totalMinutes = hours * 60 + minutes;
-                return totalMinutes + "분";
-            }
-
-            // "약 90분" 패턴
-            pattern = java.util.regex.Pattern.compile("약\\s*(\\d+)분");
-            matcher = pattern.matcher(timeStr);
-
-            if (matcher.find()) {
-                return matcher.group(1) + "분";
-            }
-
-            // 숫자만 있는 경우 (분으로 가정)
-            if (timeStr.trim().matches("\\d+")) {
-                return timeStr.trim() + "분";
-            }
-
-        } catch (Exception e) {
-            log.warn("러닝타임 추출 실패: {} - {}", timeStr, e.getMessage());
-        }
-
-        // 변환 실패 시 원본 반환
-        return timeStr;
-    }
-
-    /**
-     * 공연시간 텍스트에서 러닝타임 추출 (상세 버전)
-     * KOPIS 상세 정보의 공연시간 필드에서 러닝타임을 추출
-     *
-     * @param performanceTime 공연시간 텍스트
-     * @return 추출된 러닝타임 (분 단위, 실패 시 null)
-     */
-    public static String extractRunningTime(String performanceTime) {
-        return convertToMinutes(performanceTime);
     }
 
     /**

--- a/src/main/java/com/everyplaceinkorea/epik_boot3_api/repository/concert/ConcertRepository.java
+++ b/src/main/java/com/everyplaceinkorea/epik_boot3_api/repository/concert/ConcertRepository.java
@@ -68,11 +68,16 @@ public interface ConcertRepository extends JpaRepository<Concert, Long> {
     List<Concert> findByFacilityIsNotNullAndHallIsNull();
 
     @Query("SELECT c FROM Concert c WHERE c.kopisId IS NOT NULL " +
-            "AND (c.kopisTicketOffices IS NULL OR c.kopisTicketOffices = '{}' OR c.kopisTicketOffices = '')")
+            "AND (c.kopisTicketOffices IS NULL OR c.kopisTicketOffices = '{}' OR c.kopisTicketOffices = '')" +
+            "AND c.kopisTicketOfficesUpdatedAt IS NULL " +
+            "AND (c.kopisTicketScrapeFailCount IS NULL OR c.kopisTicketScrapeFailCount < 3)")
     Page<Concert> findConcertsWithoutTicketOffices(Pageable pageable);
 
     @Query("SELECT c FROM Concert c WHERE c.kopisId IS NOT NULL " +
-            "AND (c.kopisTicketOffices IS NULL OR c.kopisTicketOffices = '{}' OR c.kopisTicketOffices = '')")
+            "AND (c.kopisTicketOffices IS NULL OR c.kopisTicketOffices = '{}' OR c.kopisTicketOffices = '')"
+            +
+            "AND c.kopisTicketOfficesUpdatedAt IS NULL " +
+            "AND (c.kopisTicketScrapeFailCount IS NULL OR c.kopisTicketScrapeFailCount < 3)")
     List<Concert> findConcertsWithoutTicketOffices();
 
     @Query("SELECT c FROM Concert c WHERE " +

--- a/src/main/java/com/everyplaceinkorea/epik_boot3_api/repository/musical/MusicalRepository.java
+++ b/src/main/java/com/everyplaceinkorea/epik_boot3_api/repository/musical/MusicalRepository.java
@@ -96,11 +96,15 @@ public interface MusicalRepository extends JpaRepository<Musical, Long> {
     List<Musical> findByFacilityIsNotNullAndHallIsNull();
 
     @Query("SELECT m FROM Musical m WHERE m.kopisId IS NOT NULL " +
-            "AND (m.kopisTicketOffices IS NULL OR m.kopisTicketOffices = '{}' OR m.kopisTicketOffices = '')")
+            "AND (m.kopisTicketOffices IS NULL OR m.kopisTicketOffices = '{}' OR m.kopisTicketOffices = '')" +
+            "AND m.kopisTicketOfficesUpdatedAt IS NULL " +
+            "AND (m.kopisTicketScrapeFailCount IS NULL OR m.kopisTicketScrapeFailCount < 3)")
     Page<Musical> findMusicalsWithoutTicketOffices(Pageable pageable);
 
     @Query("SELECT m FROM Musical m WHERE m.kopisId IS NOT NULL " +
-            "AND (m.kopisTicketOffices IS NULL OR m.kopisTicketOffices = '{}' OR m.kopisTicketOffices = '')")
+            "AND (m.kopisTicketOffices IS NULL OR m.kopisTicketOffices = '{}' OR m.kopisTicketOffices = '')" +
+            "AND m.kopisTicketOfficesUpdatedAt IS NULL " +
+            "AND (m.kopisTicketScrapeFailCount IS NULL OR m.kopisTicketScrapeFailCount < 3)")
     List<Musical> findMusicalsWithoutTicketOffices();
 
     long countByStatus(Status status);


### PR DESCRIPTION
# PR: 예매처 스크래핑 재시도 로직 개선 및 실패 관리 구현

## 배경 및 문제

KOPIS 데이터 동기화 이후 티켓 스크래핑 배치가 실행될 때 수행 시간이 오래 걸리는 문제 발생.

**원인 분석**

- `kopis_ticket_offices IS NULL` 조건으로 조회 시 105건 반환
- 해당 105건은 KOPIS에 예매처 버튼 자체가 없어 스크래핑 결과가 항상 empty인 데이터
- "진짜 예매처 없음"과 "아직 스크래핑 안 함"을 구분하지 못하는 구조
- `delayBetweenRequests = 3000ms` 적용으로 50건 기준 최소 150초 소요

---

## 해결 과정

### 1. 기존 105건 DB 일괄 처리

`kopis_ticket_offices_updated_at`이 이미 존재하는 컬럼이나 예매처 없는 경우 null 유지 중이었음.

```sql
SET SQL_SAFE_UPDATES = 0;
UPDATE Concert SET kopis_ticket_offices_updated_at = NOW()
WHERE kopis_ticket_offices IS NULL AND kopis_ticket_offices_updated_at IS NULL;
UPDATE Musical SET kopis_ticket_offices_updated_at = NOW()
WHERE kopis_ticket_offices IS NULL AND kopis_ticket_offices_updated_at IS NULL;
SET SQL_SAFE_UPDATES = 1;
```

### 2. `kopis_ticket_scrape_fail_count` 컬럼 추가

서버 에러로 인한 실패와 진짜 예매처 없음을 구분하기 위해 재시도 횟수 카운터 추가.

- `Concert`, `Musical` 엔티티에 `Integer kopisTicketScrapeFailCount = 0` 추가

### 3. 배치 조회 쿼리 변경

```sql
-- 변경 전
WHERE kopis_ticket_offices IS NULL

-- 변경 후
WHERE kopis_ticket_offices IS NULL
  AND kopis_ticket_offices_updated_at IS NULL
  AND (kopis_ticket_scrape_fail_count IS NULL OR kopis_ticket_scrape_fail_count < 3)
```

`ConcertRepository`, `MusicalRepository` 두 메서드 모두 적용.

### 4. `scrapeWithRetry()` 메서드 추가 (`TicketOfficeSyncService`)

스크래핑 결과가 없을 경우 즉시 재시도 (최대 `maxRetryCount`회), 모든 재시도 실패 시 fail_count 증가.

**재시도 흐름**

```
스크래핑 실행
 └→ 빈 결과 → 최대 3회 재시도 (3초 간격)
      ├→ 성공 → fail_count = 0, 정상 저장
      └→ 3회 전부 실패
           ├→ fail_count 1~2 → fail_count++, updated_at null 유지 (다음 배치 재시도)
           └→ fail_count >= 3 → updated_at 세팅 (배치 영구 제외)
```

- `Concert`, `Musical` 각각 오버로딩으로 구현
- `ScrapingProperties.maxRetryCount` 기존 설정값 활용 (주입 추가)

---

## 변경 파일 목록

- `entity/concert/Concert.java` — `kopisTicketScrapeFailCount` 필드 추가 (`Integer`)
- `entity/musical/Musical.java` — 동일
- `repository/concert/ConcertRepository.java` — 쿼리 조건 변경
- `repository/musical/MusicalRepository.java` — 쿼리 조건 변경
- `external/kopis/service/TicketOfficeSyncService.java` — `scrapeWithRetry()` 추가, `ScrapingProperties` 주입

---

## 결과

- 배치 실행 시 신규 데이터만 스크래핑 대상에 포함
- 서버 에러로 실패한 경우 최대 3회 재시도 후 임계값 초과 시 배치 제외
- 수동 개별 스크래핑(`/admin/ticket/{id}/update`)은 제한 없이 항시 가능